### PR TITLE
Reduce Reflection Warnings

### DIFF
--- a/src/grete/core.clj
+++ b/src/grete/core.clj
@@ -46,7 +46,7 @@
    (gregor/send-then producer topic key msg then)))
 
 (defn close [^Producer producer]
-  (.close producer))
+  (gregor/close producer))
 
 (defn- edn-to-consumer [{:keys [bootstrap-servers
                                 group-id

--- a/src/grete/core.clj
+++ b/src/grete/core.clj
@@ -3,13 +3,17 @@
             [clojure.string :as s]
             [grete.gregor :as gregor]
             [grete.scheduler :as sch]
-            [grete.tools :as t]))
+            [grete.tools :as t])
+  (:import [java.util.concurrent ExecutorService]
+           [org.apache.kafka.clients.consumer Consumer]
+           [org.apache.kafka.clients.producer Producer]
+           [org.apache.kafka.common TopicPartition]))
 
 (defn to-prop [k]
   (-> k name (s/replace #"-" ".")))
 
 (defn to-props
-  "ranames keys by converting them to strings and substituting dashes with periods
+  "renames keys by converting them to strings and substituting dashes with periods
    only does top level keys"
   [conf]
   (into {}
@@ -41,8 +45,8 @@
   ([producer topic key msg then]
    (gregor/send-then producer topic key msg then)))
 
-(defn close [producer]
-  (gregor/close producer))
+(defn close [^Producer producer]
+  (.close producer))
 
 (defn- edn-to-consumer [{:keys [bootstrap-servers
                                 group-id
@@ -59,11 +63,11 @@
       seq))
 
 (defn poll
-  "fetches sequetially from the last consumed offset
+  "fetches sequentially from the last consumed offset
    return 'org.apache.kafka.clients.consumer.ConsumerRecords' currently available to the consumer (via a single poll)
    if a 'timeout' param is 0, returns immediately with any records that are available now."
-  ([consumer] (poll consumer 100))
-  ([consumer timeout]
+  ([^Consumer consumer] (poll consumer 100))
+  ([^Consumer consumer ^long timeout]
    (.poll consumer timeout)))
 
 (defn consumer [conf]
@@ -74,7 +78,7 @@
 (defn consume
   "the 'process' function will take 'org.apache.kafka.clients.consumer.ConsumerRecords'
    which can be turns to a seq of maps with 'consumer-records->maps'"
-  [consumer process running? ms n]
+  [^Consumer consumer process running? ms n]
   (log/info "starting" (inc n) "consumer")
   (while @running?
     (try
@@ -84,7 +88,7 @@
           (gregor/commit-offsets! consumer)))
       (catch Throwable t
         (log/error "kafka: could not consume a message" t))))
-  (gregor/close consumer))
+  (.close consumer))
 
 (defn run-consumers [process {:keys [threads poll-ms] :as conf}]
   (let [running? (atom true)
@@ -94,17 +98,17 @@
     (dotimes [t threads]
       (let [c (consumer (dissoc conf :threads :poll-ms))]
         (log/info "subscribing to:" (gregor/subscription c))
-        (.submit pool #(consume c process running? poll-ms t))))
+        (.submit pool ^Runnable #(consume c process running? poll-ms t))))
     (log/info "started" threads "consumers ->"
               (t/cloak-secrets conf))
     {:pool pool :running? running?}))
 
 (defn stop-consumers [{:keys [pool running?]}]
   (reset! running? false)
-  (.shutdown pool))
+  (.shutdown ^ExecutorService pool))
 
 (defn offsets [c]
-  (for [tp (gregor/assignment c)]
+  (for [^TopicPartition tp (gregor/assignment c)]
     (let [p (.partition tp)
           t (.topic tp)]
       {:topic t :partition p :offset (gregor/committed c t p)})))

--- a/src/grete/gregor.clj
+++ b/src/grete/gregor.clj
@@ -2,15 +2,15 @@
   "this namespace is originally developed by Cody Canning: https://github.com/ccann as a part of https://github.com/ccann/gregor
    it is moved 'into' grete to avoid dependency since 'gregor' did not seem to be actively maintained."
   (:refer-clojure :exclude [flush send])
-  (:import [org.apache.kafka.common TopicPartition]
+  (:import [java.util.regex Pattern]
+           [org.apache.kafka.common TopicPartition]
            [org.apache.kafka.clients.consumer Consumer KafkaConsumer
                                               ConsumerRecord OffsetAndMetadata OffsetCommitCallback
                                               ConsumerRebalanceListener]
            [org.apache.kafka.clients.producer Producer KafkaProducer Callback
                                               ProducerRecord]
-           [java.util.concurrent TimeUnit]
-           [org.apache.kafka.clients.admin AdminClient NewTopic]
-           [java.util Properties Map]
+           [org.apache.kafka.clients.admin AdminClient DeleteTopicsResult NewTopic]
+           [java.util Collection Properties Map]
            [org.apache.kafka.clients CommonClientConfigs])
   (:require [clojure.string :as str]))
 
@@ -20,7 +20,7 @@
 (def ^:no-doc byte-array-serializer "org.apache.kafka.common.serialization.ByteArraySerializer")
 
 (defn- as-properties
-  [m]
+  ^Properties [^Map m]
   (let [ps (Properties.)]
     (doseq [[k v] m] (.setProperty ps k v))
     ps))
@@ -59,6 +59,7 @@
 
 
 (defn- reify-crl
+  ^ConsumerRebalanceListener
   [assigned-cb revoked-cb]
   (reify ConsumerRebalanceListener
     (onPartitionsAssigned [this partitions]
@@ -84,32 +85,6 @@
    :offset         (.offset record)
    :timestamp      (.timestamp record)
    :timestamp-type (.toString (.timestampType record))})
-
-
-(defprotocol Closeable
-  "Provides two ways to close things: a default one with `(.close thing)` and the one
-   with the specified timeout."
-  (close [this]
-    [this timeout]))
-
-
-(extend-protocol Closeable
-  KafkaProducer
-  (close
-    ([p] (.close p))
-    ([p timeout]
-     ;; Tries to close the producer cleanly within the specified timeout.
-     ;; If the close does not complete within the timeout, fail any pending send
-     ;; requests and force close the producer
-     (.close p timeout TimeUnit/SECONDS)))
-  KafkaConsumer
-  (close
-    ([c] (.close c))
-    ([p timeout]
-     ;; Tries to close the consumer cleanly within the specified timeout.
-     ;; If the consumer is unable to complete offset commits and gracefully leave
-     ;; the group before the timeout expires, the consumer is force closed.
-     (.close p timeout TimeUnit/SECONDS))))
 
 
 ;;;;;;;;;;;;;;;;;;;;
@@ -189,11 +164,11 @@
   ([^Consumer consumer]
    (.commitSync consumer))
   ([^Consumer consumer offsets]
-   (let [m (into {} (for [{:keys [topic partition offset metadata]} offsets]
-                      [(topic-partition topic partition)
-                       (if metadata
-                         (offset-and-metadata offset metadata)
-                         (offset-and-metadata offset))]))]
+   (let [^Map m (into {} (for [{:keys [topic partition offset metadata]} offsets]
+                           [(topic-partition topic partition)
+                            (if metadata
+                              (offset-and-metadata offset metadata)
+                              (offset-and-metadata offset))]))]
      (.commitSync consumer m))))
 
 
@@ -220,7 +195,7 @@
 
 (defn poll
   "Return a seq of consumer records currently available to the consumer (via a single poll).
-   Fetches sequetially from the last consumed offset.
+   Fetches sequentially from the last consumed offset.
 
    A consumer record is represented as a clojure map with corresponding keys:
    `:value`, `:key`, `:partition`, `:topic`, `:offset`
@@ -228,8 +203,8 @@
    `timeout` - the time, in milliseconds, spent waiting in poll if data is not
    available. If 0, returns immediately with any records that are available now.
    Must not be negative."
-  ([consumer] (poll consumer 100))
-  ([consumer timeout]
+  ([^Consumer consumer] (poll consumer 100))
+  ([^Consumer consumer ^long timeout]
    (->> (.poll consumer timeout)
         (map consumer-record->map)
         (seq))))
@@ -268,13 +243,13 @@
 
 (defn seek!
   "Overrides the fetch offsets that the consumer will use on the next poll."
-  [^Consumer consumer topic partition offset]
+  [^Consumer consumer ^String topic ^Integer partition ^long offset]
   (.seek consumer (topic-partition topic partition) offset))
 
 
 (defn seek-to!
   "Seek to the `:beginning` or `:end` offset for each of the given partitions."
-  [consumer offset topic partition & tps]
+  [^Consumer consumer offset topic partition & tps]
   (assert (contains? #{:beginning :end} offset) "offset must be :beginning or :end")
   (let [tps (->tps "seek-to!" topic partition tps)]
     (case offset
@@ -295,8 +270,10 @@
    the optional functions are a callback interface to trigger custom actions when the set
    of partitions assigned to the consumer changes."
   [^Consumer consumer topics-or-regex & [partitions-assigned-fn partitions-revoked-fn]]
-  (.subscribe consumer topics-or-regex
-              (reify-crl partitions-assigned-fn partitions-revoked-fn)))
+  (let [crl (reify-crl partitions-assigned-fn partitions-revoked-fn)]
+    (if (instance? Pattern topics-or-regex)
+      (.subscribe consumer ^Pattern topics-or-regex crl)
+      (.subscribe consumer ^Collection topics-or-regex crl))))
 
 
 (defn subscription
@@ -371,7 +348,7 @@
   ([^String topic ^Integer partition key value]
    (ProducerRecord. topic (int partition) key value))
   ([^String topic ^Integer partition ^Long timestamp key value]
-   (ProducerRecord. topic (int partition) (long timestamp) key value)))
+   (ProducerRecord. topic ^Integer (int partition) ^Long (long timestamp) key value)))
 
 
 (defn- send-record
@@ -488,5 +465,6 @@
     topic: The name of the topic to delete."
   [^Map conf ^String topic]
   (assert (contains? conf CommonClientConfigs/BOOTSTRAP_SERVERS_CONFIG) "bootstrap server config not present")
-  (with-open [^AdminClient ac (AdminClient/create conf)]
-    (.all (.deleteTopics ac [topic]))))
+  (let [^Collection topics [topic]]
+    (with-open [^AdminClient ac (AdminClient/create conf)]
+      (.all ^DeleteTopicsResult (.deleteTopics ac topics)))))

--- a/src/grete/gregor.clj
+++ b/src/grete/gregor.clj
@@ -2,7 +2,8 @@
   "this namespace is originally developed by Cody Canning: https://github.com/ccann as a part of https://github.com/ccann/gregor
    it is moved 'into' grete to avoid dependency since 'gregor' did not seem to be actively maintained."
   (:refer-clojure :exclude [flush send])
-  (:import [java.util.regex Pattern]
+  (:import [java.time Duration]
+           [java.util.regex Pattern]
            [org.apache.kafka.common TopicPartition]
            [org.apache.kafka.clients.consumer Consumer KafkaConsumer
                                               ConsumerRecord OffsetAndMetadata OffsetCommitCallback
@@ -85,6 +86,32 @@
    :offset         (.offset record)
    :timestamp      (.timestamp record)
    :timestamp-type (.toString (.timestampType record))})
+
+
+(defprotocol Closeable
+  "Provides two ways to close things: a default one with `(.close thing)` and the one
+   with the specified timeout (in milliseconds)."
+  (close [this]
+         [this timeout]))
+
+
+(extend-protocol Closeable
+  KafkaProducer
+  (close
+    ([p] (.close p))
+    ([p timeout]
+     ;; Tries to close the producer cleanly within the specified timeout.
+     ;; If the close does not complete within the timeout, fail any pending send
+     ;; requests and force close the producer
+     (.close ^KafkaProducer p (Duration/ofMillis timeout))))
+  KafkaConsumer
+  (close
+    ([c] (.close c))
+    ([p timeout]
+     ;; Tries to close the consumer cleanly within the specified timeout.
+     ;; If the consumer is unable to complete offset commits and gracefully leave
+     ;; the group before the timeout expires, the consumer is force closed.
+     (.close ^KafkaConsumer p (Duration/ofMillis timeout)))))
 
 
 ;;;;;;;;;;;;;;;;;;;;

--- a/src/grete/java_api.clj
+++ b/src/grete/java_api.clj
@@ -1,42 +1,37 @@
 (ns grete.java-api
-  (:require [clojure.edn :as edn]
-            [clojure.tools.logging :as log]
-            [clojure.walk :refer [keywordize-keys]]
+  (:require [clojure.tools.logging :as log]
             [grete.tools :as t]
             [grete.core :as g])
-  (:import [org.apache.kafka.clients.consumer KafkaConsumer
-                                              ConsumerRecords]))
+  (:import [java.util HashMap Map]
+           [java.util.function BiConsumer]
+           [org.apache.kafka.clients.consumer KafkaConsumer ConsumerRecords]))
 
 (gen-class
   :name tolitius.Grete
-  :methods [^{:static true} [startConsumers [java.util.function.BiConsumer
-                                             java.util.Map] java.util.Map]
-            ^{:static true} [stopConsumers [java.util.Map] void]
-            ^{:static true} [resetOffsets [java.util.Map
-                                           String
-                                           Long] void]
-            ^{:static true} [toMap [java.util.Map] java.util.Map]])
+  :methods [^{:static true} [startConsumers [BiConsumer Map] Map]
+            ^{:static true} [stopConsumers [Map] void]
+            ^{:static true} [resetOffsets [Map String Long] void]
+            ^{:static true} [toMap [Map] Map]])
 
-(defn -startConsumers [consume config]
+(defn -startConsumers [^BiConsumer consume ^Map config]
   (let [f (fn [^KafkaConsumer consumer
                ^ConsumerRecords records]
             (.accept consume consumer records))
-        edn-config (-> (t/fmk config keyword)
+        edn-config (-> (update-keys config keyword)
                        (update :topics t/s->seq)
-                       (update :threads t/parse-long)
-                       (update :poll-ms t/parse-long))]
+                       (update :threads parse-long)
+                       (update :poll-ms parse-long))]
     (log/info "starting consumers with:" edn-config)
     (g/run-consumers f edn-config)))
 
-(defn -stopConsumers [consumers]
+(defn -stopConsumers [^Map consumers]
   (g/stop-consumers consumers))
 
-(defn -resetOffsets [config topic pnum]
-  (let [edn-conf (-> (t/fmk config keyword)
+(defn -resetOffsets [^Map config ^String topic ^Long pnum]
+  (let [edn-conf (-> (update-keys config keyword)
                      (dissoc :topics :threads :poll-ms))
         consumer (g/consumer edn-conf)]
     (g/reset-offsets consumer topic pnum)))
 
-(defn -toMap [m]
-  (-> (t/fmk m name)
-      (java.util.HashMap.)))
+(defn -toMap [^Map m]
+  (HashMap. ^Map (update-keys m name)))

--- a/src/grete/scheduler.clj
+++ b/src/grete/scheduler.clj
@@ -1,10 +1,7 @@
 (ns grete.scheduler
-  (:require [clojure.tools.logging :as log]
-            [grete.tools :as t])
+  (:require [clojure.tools.logging :as log])
   (:import [java.util.concurrent.atomic AtomicInteger]
-           [java.util.concurrent ThreadFactory Executors TimeUnit ScheduledExecutorService ExecutorService]
-           [java.time Instant ZoneId ZonedDateTime]
-           [java.time.format DateTimeFormatter]))
+           [java.util.concurrent Future ThreadFactory Executors TimeUnit ExecutorService]))
 
 (deftype GreteThreadFactory [name ^AtomicInteger thread-counter]
   ThreadFactory
@@ -19,13 +16,13 @@
           (uncaughtException [_ thread ex]
             (log/error (format "error in thread id: %s name: %s" (.getId thread) (.getName thread)) ex)))))))
 
-(defn new-executor [name num-threads]
+(defn ^ExecutorService new-executor [name num-threads]
    (Executors/newFixedThreadPool num-threads
                                  (GreteThreadFactory. name
                                                         (AtomicInteger. 0))))
 
 (defn run-fun [name fun threads]
-  (let [threads (or (t/parse-long (str threads)) 1)
+  (let [threads (or (parse-long (str threads)) 1)
         pool (new-executor name threads)
         running? (atom true)
         ^Runnable spinner #(while @running?
@@ -37,7 +34,7 @@
 
     {:pool pool :running? running?}))
 
-(defn stop [f]
+(defn stop [^Future f]
   (.cancel f true))
 
 (defn every [interval fun & {:keys [initial-delay time-unit]

--- a/src/grete/streams.clj
+++ b/src/grete/streams.clj
@@ -1,17 +1,16 @@
 (ns grete.streams
   (:require [clojure.string :as s]
-            [grete.tools :as t]
-            [jsonista.core :as json])
+            [grete.tools :as t])
   (:import [clojure.lang Reflector]
            [java.util Properties]
-           [org.apache.kafka.common.serialization Serde
-                                                  Serdes]
+           [org.apache.kafka.common.serialization Serdes]
            [org.apache.kafka.streams KafkaStreams
                                      KeyValue
                                      StreamsBuilder
-                                     StreamsConfig]
+                                     StreamsConfig Topology]
            [org.apache.kafka.streams.kstream Consumed
                                              KStream
+                                             KTable
                                              Named
                                              Produced
                                              Predicate
@@ -49,7 +48,7 @@
         (println "(!)" msg)
         (throw (RuntimeException. msg e))))))
 
-(defn to-stream-config [m]
+(defn ^Properties to-stream-config [m]
   (let [ps (Properties.)]
     (doseq [[k v] m]
       (.put ps (to-stream-prop k)
@@ -74,45 +73,41 @@
 
 ;; directing flow
 
-(defn topic->stream
-  ([builder topic]
+(defn ^KStream topic->stream
+  ([^StreamsBuilder builder ^String topic]
    (topic->stream builder topic {}))
-  ([builder topic {:keys [key-serde value-serde]
-                   :or {key-serde (string-serde)
-                        value-serde (string-serde)}}]
-   (.stream builder topic (Consumed/with key-serde
-                                         value-serde))))
+  ([^StreamsBuilder builder ^String topic {:keys [key-serde value-serde]
+                                           :or   {key-serde   (string-serde)
+                                                  value-serde (string-serde)}}]
+   (.stream builder topic (Consumed/with key-serde value-serde))))
 
 (defn topic->table
-  ([builder topic]
+  ([^StreamsBuilder builder ^String topic]
    (topic->table builder topic {}))
-  ([builder topic {:keys [key-serde value-serde]
-                   :or {key-serde (string-serde)
-                        value-serde (string-serde)}}]
-   (.table builder topic (Consumed/with key-serde
-                                        value-serde))))
+  ([^StreamsBuilder builder ^String topic {:keys [key-serde value-serde]
+                                           :or   {key-serde   (string-serde)
+                                                  value-serde (string-serde)}}]
+   (.table builder topic (Consumed/with key-serde value-serde))))
 
 (defn topic->global-table
-  ([builder topic]
+  ([^StreamsBuilder builder ^String topic]
    (topic->global-table builder topic {}))
-  ([builder topic {:keys [key-serde value-serde]
-                   :or {key-serde (string-serde)
-                        value-serde (string-serde)}}]
-   (.globalTable builder topic (Consumed/with key-serde
-                                              value-serde))))
+  ([^StreamsBuilder builder ^String topic {:keys [key-serde value-serde]
+                                           :or   {key-serde   (string-serde)
+                                                  value-serde (string-serde)}}]
+   (.globalTable builder topic (Consumed/with key-serde value-serde))))
 
 (defn stream->topic
-  ([stream topic]
+  ([^KStream stream ^String topic]
    (stream->topic stream topic {}))
-  ([stream topic {:keys [key-serde value-serde]
-                   :or {key-serde (string-serde)
-                        value-serde (string-serde)}}]
-   (.to stream topic (Produced/with key-serde
-                                    value-serde))))
+  ([^KStream stream ^String topic {:keys [key-serde value-serde]
+                                   :or   {key-serde   (string-serde)
+                                          value-serde (string-serde)}}]
+   (.to stream topic (Produced/with key-serde value-serde))))
 
 ;; ->fn kafka stream wrappers
 
-(defn named-as [op f]
+(defn ^Named named-as [op f]
   (Named/as (str
               (name op) "." (t/stream-fn->name f))))
 
@@ -124,12 +119,12 @@
 (defn map-values
   ([fun]
    (partial map-values fun))
-  ([fun stream]
+  ([fun ^KStream stream]
    (.mapValues stream
                (FunValueMapper. fun)
                (named-as :map-values fun))))
 
-(defn to-kv [[k v]]
+(defn ^KeyValue to-kv [[k v]]
   (KeyValue. k v))
 
 (deftype FunKeyValueMapper [fun]
@@ -141,7 +136,7 @@
 (defn map-kv
   ([fun]
    (partial map-kv fun))
-  ([fun stream]
+  ([fun ^KStream stream]
    (.map stream
          (FunKeyValueMapper. fun)
          (named-as :map-kv fun))))
@@ -154,7 +149,7 @@
 (defn filter-kv
   ([fun]
    (partial filter-kv fun))
-  ([fun stream]
+  ([fun ^KStream stream]
    (.filter stream
             (FunPredicate. fun)
             (named-as :filter fun))))
@@ -167,7 +162,7 @@
 (defn left-join
   ([fun]
    (partial left-join fun))
-  ([fun stream table]
+  ([fun ^KStream stream ^KTable table]
    (.leftJoin stream
               table
               (FunValueJoiner. fun)))) ;; KStream.leftJoin(KTable ..) does not have a Named arg ¯\_(ツ)_/¯
@@ -184,7 +179,7 @@
    (unlike peek, which is not a terminal operation)"
   ([fun]
    (partial for-each fun))
-  ([fun stream]
+  ([fun ^KStream stream]
    (.foreach stream
              (FunForeachAction. fun)
              (named-as :for-each fun))))
@@ -197,7 +192,7 @@
    peek is helpful for use cases such as logging or tracking metrics or for debugging and troubleshooting"
   ([fun]
    (partial peek fun))
-  ([fun stream]
+  ([fun ^KStream stream]
    (.peek stream
           (FunForeachAction. fun)
           (named-as :peek fun))))
@@ -205,25 +200,25 @@
 
 ;; topology plumbing
 
-(defn make-streams [config builder]
+(defn make-streams [config ^StreamsBuilder builder]
   (let [topology (.build builder)]
     {:topology topology
      :streams (KafkaStreams. topology
                              (to-stream-config config))}))
 
 (defn describe-topology [streams]
-  (-> streams :topology .describe))
+  (.describe ^Topology (:topology streams)))
 
 (defn start-streams [streams]
-  (.start (-> streams :streams))
+  (.start ^KafkaStreams (:streams streams))
   streams)
 
 (defn cleanup-streams [streams]
-  (.cleanUp (-> streams :streams))
+  (.cleanUp ^KafkaStreams (:streams streams))
   streams)
 
 (defn stop-streams [streams]
-  (.close (-> streams :streams))
+  (.close ^KafkaStreams (:streams streams))
   streams)
 
 (defn stream-on! [config make-topology]

--- a/src/grete/tools.clj
+++ b/src/grete/tools.clj
@@ -1,11 +1,16 @@
 (ns grete.tools
   (:require [clojure.string :as s]))
 
+(defn parse-long [n]
+  (when n
+    (try (Long/valueOf n)
+         (catch Exception e))))
+
 (defn s->seq [xs]
   (when (seq xs)
     (s/split xs #",")))
 
-(defn ^String kebab->screaming-snake [k]
+(defn kebab->screaming-snake [k]
   (-> k
       name
       (s/replace #"-" "_")
@@ -20,6 +25,20 @@
   (if (coll? x)
     x
     [x]))
+
+(defn fmv
+  "apply f to each value v of map m"
+  [m f]
+  (into {}
+        (for [[k v] m]
+          [k (f v)])))
+
+(defn fmk
+  "apply f to each key k of map m"
+  [m f]
+  (into {}
+        (for [[k v] m]
+          [(f k) v])))
 
 (defn random-string []
   (apply str

--- a/src/grete/tools.clj
+++ b/src/grete/tools.clj
@@ -1,16 +1,11 @@
 (ns grete.tools
   (:require [clojure.string :as s]))
 
-(defn parse-long [n]
-  (when n
-    (try (Long/valueOf n)
-         (catch Exception e))))
-
 (defn s->seq [xs]
   (when (seq xs)
     (s/split xs #",")))
 
-(defn kebab->screaming-snake [k]
+(defn ^String kebab->screaming-snake [k]
   (-> k
       name
       (s/replace #"-" "_")
@@ -25,20 +20,6 @@
   (if (coll? x)
     x
     [x]))
-
-(defn fmv
-  "apply f to each value v of map m"
-  [m f]
-  (into {}
-        (for [[k v] m]
-          [k (f v)])))
-
-(defn fmk
-  "apply f to each key k of map m"
-  [m f]
-  (into {}
-        (for [[k v] m]
-          [(f k) v])))
 
 (defn random-string []
   (apply str


### PR DESCRIPTION
- Remove many reflection warnings by adding type hints throughout the codebase.

- Update the `Closeable` protocol. The signatures for `.close` have changed, the `close(long, TimeUnit)` signature no longer exists in the Kafka 3.x client API. Replace with calls to `close(Duration)`.

- Remove unused imports

- Fix typos