### PR TITLE
Upgrade Kafka Streams dependency to 4.3.0

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
 
  :deps {org.clojure/tools.logging {:mvn/version "1.2.4"}
         metosin/jsonista {:mvn/version "0.3.5"}
-        org.apache.kafka/kafka-streams {:mvn/version "3.0.0"}}
+        org.apache.kafka/kafka-streams {:mvn/version "4.3.0"}}
 
  :aliases {:dev {:extra-paths ["dev" "dev-resources"]
                  :extra-deps {metosin/jsonista {:mvn/version "0.3.4"}

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-streams</artifactId>
-      <version>3.0.0</version>
+      <version>4.3.0</version>
     </dependency>
     <dependency>
       <groupId>metosin</groupId>

--- a/src/grete/core.clj
+++ b/src/grete/core.clj
@@ -3,7 +3,8 @@
             [clojure.string :as s]
             [grete.gregor :as gregor]
             [grete.scheduler :as sch]
-            [grete.tools :as t]))
+            [grete.tools :as t])
+  (:import [java.time Duration]))
 
 (defn to-prop [k]
   (-> k name (s/replace #"-" ".")))
@@ -64,7 +65,7 @@
    if a 'timeout' param is 0, returns immediately with any records that are available now."
   ([consumer] (poll consumer 100))
   ([consumer timeout]
-   (.poll consumer timeout)))
+   (.poll consumer (Duration/ofMillis timeout))))
 
 (defn consumer [conf]
   (log/info "consumer config:" (t/cloak-secrets conf))

--- a/src/grete/gregor.clj
+++ b/src/grete/gregor.clj
@@ -8,7 +8,7 @@
                                               ConsumerRebalanceListener]
            [org.apache.kafka.clients.producer Producer KafkaProducer Callback
                                               ProducerRecord]
-           [java.util.concurrent TimeUnit]
+           [java.time Duration]
            [org.apache.kafka.clients.admin AdminClient NewTopic]
            [java.util Properties Map]
            [org.apache.kafka.clients CommonClientConfigs])
@@ -101,7 +101,7 @@
      ;; Tries to close the producer cleanly within the specified timeout.
      ;; If the close does not complete within the timeout, fail any pending send
      ;; requests and force close the producer
-     (.close p timeout TimeUnit/SECONDS)))
+     (.close p (Duration/ofSeconds timeout))))
   KafkaConsumer
   (close
     ([c] (.close c))
@@ -109,7 +109,7 @@
      ;; Tries to close the consumer cleanly within the specified timeout.
      ;; If the consumer is unable to complete offset commits and gracefully leave
      ;; the group before the timeout expires, the consumer is force closed.
-     (.close p timeout TimeUnit/SECONDS))))
+     (.close p (Duration/ofSeconds timeout)))))
 
 
 ;;;;;;;;;;;;;;;;;;;;
@@ -202,12 +202,13 @@
    offset will be used as the position for the consumer in the event of a failure. If no
    offsets have been committed, return `nil`."
   [^Consumer consumer ^String topic ^Integer partition]
-  (when-let [offset (.committed consumer (topic-partition topic partition))]
-    (let [m {:offset (.offset offset)
-             :metadata (.metadata offset)}]
-      (if (clojure.string/blank? (:metadata m))
-        (assoc m :metadata nil)
-        m))))
+  (let [tp (topic-partition topic partition)]
+    (when-let [offset (get (.committed consumer #{tp}) tp)]
+      (let [m {:offset (.offset offset)
+               :metadata (.metadata offset)}]
+        (if (clojure.string/blank? (:metadata m))
+          (assoc m :metadata nil)
+          m)))))
 
 
 (defn pause
@@ -230,7 +231,7 @@
    Must not be negative."
   ([consumer] (poll consumer 100))
   ([consumer timeout]
-   (->> (.poll consumer timeout)
+   (->> (.poll consumer (Duration/ofMillis timeout))
         (map consumer-record->map)
         (seq))))
 


### PR DESCRIPTION
Changes
  - Upgrade org.apache.kafka/kafka-streams from 3.0.0 to 4.3.0 in deps.edn.
  - Upgrade Maven kafka-streams dependency from 3.0.0 to 4.3.0 in pom.xml.
  - Update Kafka consumer poll calls to use java.time.Duration/ofMillis, matching Kafka 4.x Java client APIs while preserving grete’s existing millisecond timeout behavior.
  - Update producer/consumer timeout close calls to use Duration/ofSeconds, preserving the previous timeout unit behavior.
  - Update committed-offset lookup to call Kafka 4.x committed(Set<TopicPartition>) and return the same grete map shape as before.

Note on timeout units:
  - consumer poll uses Duration/ofMillis because grete documents poll timeout as milliseconds.
  - producer/consumer close(timeout) uses Duration/ofSeconds because the existing implementation used TimeUnit/SECONDS, so this preserves existing grete behaviour while adapting to the Kafka 4.x duration API.


Validation:
Tested grete with Kafka client dependency 4.3.0 against local KRaft brokers:

  - Apache Kafka 4.3.0: passed (latest upstream Apache Kafka version tested)
  - Confluent Kafka 7.9.7: passed (safe 7.x bridge version before moving to 8.x)
  - Confluent Kafka 8.2.1: passed (latest Confluent Platform/Community version tested)